### PR TITLE
[동호회 가입 신청 및 승인 / 거절]

### DIFF
--- a/src/main/java/com/team6/finalproject/club/apply/entity/ApplyJoinClub.java
+++ b/src/main/java/com/team6/finalproject/club/apply/entity/ApplyJoinClub.java
@@ -1,26 +1,25 @@
-package com.team6.finalproject.club.member.entity;
+package com.team6.finalproject.club.apply.entity;
 
 import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.club.enums.ApprovalStateEnum;
 import com.team6.finalproject.common.entity.Timestamped;
 import com.team6.finalproject.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Entity
 @Getter
+@Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member",
-        uniqueConstraints = @UniqueConstraint(
-                name = "DuplicateClubMember",
-                columnNames = {
-                        "user_id", "club_id"})
-)
-public class Member extends Timestamped {
+public class ApplyJoinClub extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "approval_state")
+    @Enumerated(value = EnumType.STRING)
+    private ApprovalStateEnum approvalStateEnum;
 
     @Column(name = "is_deleted")
     private boolean isDeleted;
@@ -33,4 +32,9 @@ public class Member extends Timestamped {
     @JoinColumn(name = "club_id")
     private Club club;
 
+
+    public void updateApprovalState(ApprovalStateEnum approvalStateEnum) {
+        this.approvalStateEnum = approvalStateEnum;
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/team6/finalproject/club/apply/repository/ApplyJoinClubRepository.java
+++ b/src/main/java/com/team6/finalproject/club/apply/repository/ApplyJoinClubRepository.java
@@ -1,0 +1,9 @@
+package com.team6.finalproject.club.apply.repository;
+
+import com.team6.finalproject.club.apply.entity.ApplyJoinClub;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplyJoinClubRepository extends JpaRepository<ApplyJoinClub, Long>, ApplyJoinClubRepositoryCustom {
+}

--- a/src/main/java/com/team6/finalproject/club/apply/repository/ApplyJoinClubRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/club/apply/repository/ApplyJoinClubRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.team6.finalproject.club.apply.repository;
+
+import com.team6.finalproject.club.apply.entity.ApplyJoinClub;
+
+import java.util.Optional;
+
+public interface ApplyJoinClubRepositoryCustom {
+
+    public Optional<ApplyJoinClub> findByActiveId(Long id);
+    public Optional<ApplyJoinClub> findByPendingApplication(Long userId, Long clubId);
+}

--- a/src/main/java/com/team6/finalproject/club/apply/repository/ApplyJoinClubRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/club/apply/repository/ApplyJoinClubRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.team6.finalproject.club.apply.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team6.finalproject.club.apply.entity.ApplyJoinClub;
+import com.team6.finalproject.club.enums.ApprovalStateEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.team6.finalproject.club.apply.entity.QApplyJoinClub.applyJoinClub;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplyJoinClubRepositoryCustomImpl implements ApplyJoinClubRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override // 유효한 가입 신청서 조회
+    public Optional<ApplyJoinClub> findByActiveId(Long id){
+        return
+                Optional.ofNullable(
+                        jpaQueryFactory
+                                .selectFrom(applyJoinClub)
+                                .where(applyJoinClub.id.eq(id)
+                                        .and(applyJoinClub.isDeleted.eq(false)))
+                                .fetchOne()
+                );
+    }
+
+    @Override // 가입 승인 대기 중인 신청서 조회 => 동일한 동호회에 중복 승인을 방지하기 위한 쿼리
+    public Optional<ApplyJoinClub> findByPendingApplication(Long userId, Long clubId) {
+        return
+                Optional.ofNullable(
+                        jpaQueryFactory
+                                .selectFrom(applyJoinClub)
+                                .where(applyJoinClub.approvalStateEnum.eq(ApprovalStateEnum.PENDING)
+                                        .and(applyJoinClub.user.id.eq(userId))
+                                        .and(applyJoinClub.club.id.eq(clubId)))
+                                .fetchOne()
+                );
+    }
+}

--- a/src/main/java/com/team6/finalproject/club/apply/service/ApplyJoinClubService.java
+++ b/src/main/java/com/team6/finalproject/club/apply/service/ApplyJoinClubService.java
@@ -1,0 +1,10 @@
+package com.team6.finalproject.club.apply.service;
+
+import com.team6.finalproject.club.apply.entity.ApplyJoinClub;
+
+
+public interface ApplyJoinClubService {
+    public void saveApplyJoinClub(ApplyJoinClub apply); // 신청서 DB 저장
+    public Boolean hasPendingApplication(Long userId, Long clubId); // 이미 존재하는 신청서 확인 논리 판단
+    public ApplyJoinClub findApplication(Long applyId); // 신청서 조회
+}

--- a/src/main/java/com/team6/finalproject/club/apply/service/ApplyJoinClubServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/apply/service/ApplyJoinClubServiceImpl.java
@@ -1,0 +1,30 @@
+package com.team6.finalproject.club.apply.service;
+
+import com.team6.finalproject.club.apply.entity.ApplyJoinClub;
+import com.team6.finalproject.club.apply.repository.ApplyJoinClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ApplyJoinClubServiceImpl implements ApplyJoinClubService{
+    private final ApplyJoinClubRepository applyJoinClubRepository;
+
+    @Override
+    @Transactional
+    public void saveApplyJoinClub(ApplyJoinClub apply) { // 신청서 DB 저장
+        applyJoinClubRepository.save(apply);
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public Boolean hasPendingApplication(Long userId, Long clubId){ // 이미 존재하는 신청서 확인 논리 판단
+        return applyJoinClubRepository.findByPendingApplication(userId, clubId).isPresent();
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public ApplyJoinClub findApplication(Long applyId) { // 신청서 조회
+        return applyJoinClubRepository.findByActiveId(applyId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 신청입니다."));
+    }
+}

--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -2,6 +2,7 @@ package com.team6.finalproject.club.controller;
 
 import com.team6.finalproject.club.dto.ClubRequestDto;
 import com.team6.finalproject.club.dto.ClubResponseDto;
+import com.team6.finalproject.club.enums.ApprovalStateEnum;
 import com.team6.finalproject.club.service.ClubService;
 import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.security.UserDetailsImpl;
@@ -26,5 +27,20 @@ public class ClubController {
     @DeleteMapping("/clubs/{clubId}")
     public ResponseEntity<ApiResponseDto> deleteClub(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.deleteClub(clubId, userDetails.getUser());
+    }
+
+    @PutMapping("clubs/{clubId}/apply")
+    public ResponseEntity<ApiResponseDto> applyJoinClub(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return clubService.joinClub(clubId, userDetails.getUser());
+    }
+
+    @PutMapping("/clubs/{applyId}/approve")
+    public ResponseEntity<ApiResponseDto> approveJoinRequest(@PathVariable Long applyId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return clubService.processClubApproval(applyId, userDetails.getUser(), ApprovalStateEnum.APPROVE);
+    }
+
+    @PutMapping("/clubs/{applyId}/refuse")
+    public ResponseEntity<ApiResponseDto> refuseJoinRequest(@PathVariable Long applyId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return clubService.processClubApproval(applyId, userDetails.getUser(), ApprovalStateEnum.REFUSE);
     }
 }

--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -20,26 +20,26 @@ public class ClubController {
 
     private final ClubService clubService;
 
-    @PostMapping("/clubs")
+    @PostMapping("/clubs") // 동호회 개설
     public ClubResponseDto createClub(@RequestBody ClubRequestDto clubRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.createClub(clubRequestDto, userDetails.getUser());
     }
-    @DeleteMapping("/clubs/{clubId}")
+    @DeleteMapping("/clubs/{clubId}") // 동호회 폐쇄
     public ResponseEntity<ApiResponseDto> deleteClub(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.deleteClub(clubId, userDetails.getUser());
     }
 
-    @PutMapping("clubs/{clubId}/apply")
+    @PutMapping("clubs/{clubId}/apply") // 동호회 가입 신청
     public ResponseEntity<ApiResponseDto> applyJoinClub(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.joinClub(clubId, userDetails.getUser());
     }
 
-    @PutMapping("/clubs/{applyId}/approve")
+    @PutMapping("/clubs/{applyId}/approve") // 동호회 가입 승인
     public ResponseEntity<ApiResponseDto> approveJoinRequest(@PathVariable Long applyId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.processClubApproval(applyId, userDetails.getUser(), ApprovalStateEnum.APPROVE);
     }
 
-    @PutMapping("/clubs/{applyId}/refuse")
+    @PutMapping("/clubs/{applyId}/refuse") // 동호회 가입 거절
     public ResponseEntity<ApiResponseDto> refuseJoinRequest(@PathVariable Long applyId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.processClubApproval(applyId, userDetails.getUser(), ApprovalStateEnum.REFUSE);
     }

--- a/src/main/java/com/team6/finalproject/club/enums/ApprovalStateEnum.java
+++ b/src/main/java/com/team6/finalproject/club/enums/ApprovalStateEnum.java
@@ -1,0 +1,22 @@
+package com.team6.finalproject.club.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ApprovalStateEnum {
+    PENDING("PENDING"), // 대기
+    APPROVE("APPROVE"), // 승인
+    REFUSE("REFUSE"); // 거절
+
+    private final String approvalState;
+
+    ApprovalStateEnum(String approvalState) {
+        this.approvalState = approvalState;
+    }
+
+    private static class ApprovalState {
+        public static final String PENDING= "PENDING";
+        public static final String APPROVAL = "APPROVE";
+        public static final String REFUSE = "REFUSE";
+    }
+}

--- a/src/main/java/com/team6/finalproject/club/member/entity/Member.java
+++ b/src/main/java/com/team6/finalproject/club/member/entity/Member.java
@@ -1,0 +1,31 @@
+package com.team6.finalproject.club.member.entity;
+
+import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.common.entity.Timestamped;
+import com.team6.finalproject.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "member")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+}

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepository.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.team6.finalproject.club.member.repository;
+
+import com.team6.finalproject.club.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom{
+}

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.team6.finalproject.club.member.repository;
+
+import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.club.member.entity.Member;
+import com.team6.finalproject.user.entity.User;
+
+import java.util.Optional;
+
+public interface MemberRepositoryCustom {
+    public Optional<Member> findActiveUserAndClub(User user, Club club);
+}

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package com.team6.finalproject.club.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.club.member.entity.Member;
+import com.team6.finalproject.club.member.entity.QMember;
+import com.team6.finalproject.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.team6.finalproject.club.member.entity.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Member> findActiveUserAndClub(User user, Club club){
+        return
+                Optional.ofNullable(
+                        jpaQueryFactory
+                                .selectFrom(member)
+                                .where(member.user.eq(user)
+                                        .and(member.club.eq(club))
+                                        .and(member.user.isDeleted.eq(false))
+                                        .and(member.club.isDeleted.eq(false)))
+                                .fetchOne()
+                );
+    }
+}

--- a/src/main/java/com/team6/finalproject/club/member/service/MemberService.java
+++ b/src/main/java/com/team6/finalproject/club/member/service/MemberService.java
@@ -1,0 +1,24 @@
+package com.team6.finalproject.club.member.service;
+
+import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.club.member.entity.Member;
+import com.team6.finalproject.club.member.repository.MemberRepository;
+import com.team6.finalproject.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    // Member Save
+    public void saveMember(Member member) {
+        memberRepository.save(member);
+    }
+
+    // 동호회 가입 여부
+    public Boolean existJoinClub(User user, Club club) {
+        return memberRepository.findActiveUserAndClub(user, club).isPresent();
+    }
+}

--- a/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustom.java
@@ -5,7 +5,7 @@ import com.team6.finalproject.club.entity.Club;
 import java.util.Optional;
 
 public interface ClubRepositoryCustom {
-    public Optional<Club> findActiveClubById(Long id);
-    public Optional<Club> findActiveClubByName(String name);
-    public Optional<Club> findActiveByIdAndUsername(Long id, String username);
+    public Optional<Club> findByActiveId(Long id);
+    public Optional<Club> findByActiveClubName(String name);
+    public Optional<Club> findByActiveIdAndUsername(Long id, String username);
 }

--- a/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustomImpl.java
@@ -16,7 +16,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Club> findActiveClubById(Long id){
+    public Optional<Club> findByActiveId(Long id){
         return
                 Optional.ofNullable(
                         jpaQueryFactory
@@ -28,7 +28,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom{
     }
 
     @Override
-    public Optional<Club> findActiveClubByName(String name){
+    public Optional<Club> findByActiveClubName(String name){
         return
                 Optional.ofNullable(
                         jpaQueryFactory
@@ -40,7 +40,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom{
     }
 
     @Override
-    public Optional<Club> findActiveByIdAndUsername(Long id, String username) {
+    public Optional<Club> findByActiveIdAndUsername(Long id, String username) {
         return
                 Optional.ofNullable(
                         jpaQueryFactory

--- a/src/main/java/com/team6/finalproject/club/service/ClubService.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubService.java
@@ -14,9 +14,9 @@ public interface ClubService {
     public ClubResponseDto createClub(ClubRequestDto clubRequestDto, User user);
 
     // 동호회 폐쇄
-    public ResponseEntity<ApiResponseDto> deleteClub(Long id, User user);
+    public ResponseEntity<ApiResponseDto> deleteClub(Long clubId, User user);
 
-    public Club findClub(Long id);
+    public Club findClub(Long clubId);
 
     // 동호회 가입 신청
     public ResponseEntity<ApiResponseDto> joinClub(Long clubId, User user);

--- a/src/main/java/com/team6/finalproject/club/service/ClubService.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubService.java
@@ -3,6 +3,7 @@ package com.team6.finalproject.club.service;
 import com.team6.finalproject.club.dto.ClubRequestDto;
 import com.team6.finalproject.club.dto.ClubResponseDto;
 import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.club.enums.ApprovalStateEnum;
 import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.user.entity.User;
 import org.springframework.http.ResponseEntity;
@@ -16,5 +17,11 @@ public interface ClubService {
     public ResponseEntity<ApiResponseDto> deleteClub(Long id, User user);
 
     public Club findClub(Long id);
+
+    // 동호회 가입 신청
+    public ResponseEntity<ApiResponseDto> joinClub(Long clubId, User user);
+
+    // 동호회 가입 신청 승인 및 거절
+    public ResponseEntity<ApiResponseDto> processClubApproval(Long applyId, User user, ApprovalStateEnum approvalState);
 }
 

--- a/src/main/java/com/team6/finalproject/club/service/ClubService.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubService.java
@@ -2,6 +2,7 @@ package com.team6.finalproject.club.service;
 
 import com.team6.finalproject.club.dto.ClubRequestDto;
 import com.team6.finalproject.club.dto.ClubResponseDto;
+import com.team6.finalproject.club.entity.Club;
 import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.user.entity.User;
 import org.springframework.http.ResponseEntity;
@@ -13,5 +14,7 @@ public interface ClubService {
 
     // 동호회 폐쇄
     public ResponseEntity<ApiResponseDto> deleteClub(Long id, User user);
+
+    public Club findClub(Long id);
 }
 

--- a/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
@@ -103,8 +103,9 @@ public class ClubServiceImpl implements ClubService{
     }
 
     // 동호회 조회 메서드
-    public void findClub(Long id) {
-        clubRepository.findActiveClubById(id)
+    @Override
+    public Club findClub(Long id) {
+        return clubRepository.findActiveClubById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동호회입니다."));
     }
 }

--- a/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
@@ -49,7 +49,7 @@ public class ClubServiceImpl implements ClubService {
         InterestMinor interestMinor = interestMinorService.existsInterestMinor(clubRequestDto.getMinorId());
 
         // 동호회 이름 존재 확인
-        if (clubRepository.findActiveClubByName(clubRequestDto.getName()).isPresent()) { // isPresent(): 존재하면 true, 존재하지 않으면 false
+        if (clubRepository.findByActiveClubName(clubRequestDto.getName()).isPresent()) { // isPresent(): 존재하면 true, 존재하지 않으면 false
             throw new IllegalArgumentException("동호회 이름이 이미 존재합니다.");
         }
 
@@ -101,7 +101,7 @@ public class ClubServiceImpl implements ClubService {
 
         //  본인 동호회인지 확인 및 동호회 존재 여부 확인
         // QueryDsl 로 삭제된 동호회는 조회 x
-        Club targetClub = clubRepository.findActiveByIdAndUsername(clubId, user.getUsername())
+        Club targetClub = clubRepository.findByActiveIdAndUsername(clubId, user.getUsername())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동호회입니다."));
 
         // Soft - Delete 메서드
@@ -188,7 +188,7 @@ public class ClubServiceImpl implements ClubService {
     // 동호회 조회 메서드
     @Override
     public Club findClub(Long id) {
-        return clubRepository.findActiveClubById(id)
+        return clubRepository.findByActiveId(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동호회입니다."));
     }
 }

--- a/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
@@ -97,16 +97,16 @@ public class ClubServiceImpl implements ClubService {
     // 동호회 폐쇄
     @Override
     @Transactional
-    public ResponseEntity<ApiResponseDto> deleteClub(Long id, User user) {
+    public ResponseEntity<ApiResponseDto> deleteClub(Long clubId, User user) {
 
         //  본인 동호회인지 확인 및 동호회 존재 여부 확인
         // QueryDsl 로 삭제된 동호회는 조회 x
-        Club club = clubRepository.findActiveByIdAndUsername(id, user.getUsername())
+        Club targetClub = clubRepository.findActiveByIdAndUsername(clubId, user.getUsername())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동호회입니다."));
 
         // Soft - Delete 메서드
         // 동호회 멤버도 delete 하기
-        club.deleteClub();
+        targetClub.deleteClub();
 
         // 반환
         return ResponseEntity.ok().body(new ApiResponseDto("동호회 삭제 성공", 200));
@@ -147,12 +147,12 @@ public class ClubServiceImpl implements ClubService {
         }
 
         // 가입 신청서 제출
-        ApplyJoinClub apply = ApplyJoinClub.builder()
+        ApplyJoinClub application = ApplyJoinClub.builder()
                 .approvalStateEnum(ApprovalStateEnum.PENDING)
                 .user(user)
                 .club(targetClub)
                 .build();
-        applyJoinClubService.saveApplyJoinClub(apply);
+        applyJoinClubService.saveApplyJoinClub(application);
         return ResponseEntity.ok().body(new ApiResponseDto("동호회 가입 신청 성공", 200));
     }
 

--- a/src/main/java/com/team6/finalproject/profile/entity/Profile.java
+++ b/src/main/java/com/team6/finalproject/profile/entity/Profile.java
@@ -37,7 +37,7 @@ public class Profile extends Timestamped {
     @Column(nullable = false)
     private Long userScore;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/team6/finalproject/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/team6/finalproject/profile/repository/ProfileRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface ProfileRepository extends JpaRepository<Profile, Long> {
+public interface ProfileRepository extends JpaRepository<Profile, Long>, ProfileRepositoryCustom {
     Optional<Profile> findByUserId(Long id);
 }

--- a/src/main/java/com/team6/finalproject/profile/repository/ProfileRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/profile/repository/ProfileRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.team6.finalproject.profile.repository;
+
+import com.team6.finalproject.profile.entity.Profile;
+
+import java.util.Optional;
+
+public interface ProfileRepositoryCustom {
+    public Optional<Profile> existValidLocate(Long id);
+    public Optional<Profile> existValidInterest(Long id);
+}

--- a/src/main/java/com/team6/finalproject/profile/repository/ProfileRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/profile/repository/ProfileRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.team6.finalproject.profile.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team6.finalproject.profile.entity.Profile;
+import com.team6.finalproject.profile.entity.QProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.team6.finalproject.profile.entity.QProfile.profile;
+
+@Repository
+@RequiredArgsConstructor
+public class ProfileRepositoryCustomImpl implements ProfileRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Profile> existValidLocate(Long id) {
+        return
+                Optional.ofNullable(
+                        jpaQueryFactory
+                                .selectFrom(profile)
+                                .where(profile.user.id.eq(id)
+                                        .and(profile.locate.isNotNull())
+                                        .and(profile.user.isDeleted.eq(false)))
+                                .fetchOne()
+                );
+    }
+
+    @Override
+    public Optional<Profile> existValidInterest(Long id) {
+        return
+                Optional.ofNullable(
+                        jpaQueryFactory
+                                .selectFrom(profile)
+                                .where(profile.user.id.eq(id)
+                                        .and(profile.profileInterests.isNotEmpty())
+                                        .and(profile.user.isDeleted.eq(false)))
+                                .fetchOne()
+                );
+    }
+}

--- a/src/main/java/com/team6/finalproject/profile/service/ProfileService.java
+++ b/src/main/java/com/team6/finalproject/profile/service/ProfileService.java
@@ -23,4 +23,10 @@ public interface ProfileService {
     // 현재 인가된 유저의 프로필 이름 추출
     Profile findProfileByUserId(Long id);
 
+    // 거주지 입력 여부 확인 메서드
+    public Boolean existValidLocate(Long id);
+
+    // 관심사 등록 여부 확인 메서드
+    public Boolean existValidInterest(Long id);
+
 }

--- a/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
@@ -102,4 +102,14 @@ public class ProfileServiceImpl implements ProfileService {
         return profileRepository.findByUserId(id).orElseThrow(
                 () -> new IllegalArgumentException("프로필을 찾을 수 없습니다."));
     }
+
+    @Override
+    public Boolean existValidLocate(Long id) {
+        return profileRepository.existValidLocate(id).isEmpty();
+    }
+
+    @Override
+    public Boolean existValidInterest(Long id) {
+        return profileRepository.existValidInterest(id).isEmpty();
+    }
 }

--- a/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
@@ -103,12 +103,12 @@ public class ProfileServiceImpl implements ProfileService {
                 () -> new IllegalArgumentException("프로필을 찾을 수 없습니다."));
     }
 
-    @Override
+    @Override // 위치 기입 했는지 확인
     public Boolean existValidLocate(Long id) {
         return profileRepository.existValidLocate(id).isEmpty();
     }
 
-    @Override
+    @Override // 관심사 등록했는지 확인
     public Boolean existValidInterest(Long id) {
         return profileRepository.existValidInterest(id).isEmpty();
     }

--- a/src/main/java/com/team6/finalproject/user/entity/User.java
+++ b/src/main/java/com/team6/finalproject/user/entity/User.java
@@ -26,7 +26,7 @@ public class User {
     private Long oAuth_id;
     private String birth;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "profile_id")
+    @OneToOne
     private Profile profile;
 
     public User(String userName, String password, String email, String birth, UserRoleEnum role) {

--- a/src/main/java/com/team6/finalproject/user/entity/User.java
+++ b/src/main/java/com/team6/finalproject/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.team6.finalproject.user.entity;
 
+import com.team6.finalproject.profile.entity.Profile;
 import com.team6.finalproject.user.dto.SignupRequestDto;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -24,6 +25,9 @@ public class User {
     private UserRoleEnum role;
     private Long oAuth_id;
     private String birth;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "profile_id")
+    private Profile profile;
 
     public User(String userName, String password, String email, String birth, UserRoleEnum role) {
         this.username = userName;

--- a/src/main/java/com/team6/finalproject/user/service/UserService.java
+++ b/src/main/java/com/team6/finalproject/user/service/UserService.java
@@ -1,19 +1,13 @@
 package com.team6.finalproject.user.service;
 
-import com.team6.finalproject.club.entity.Club;
-import com.team6.finalproject.club.member.entity.Member;
 import com.team6.finalproject.club.member.service.MemberService;
 import com.team6.finalproject.club.service.ClubService;
-import com.team6.finalproject.common.dto.ApiResponseDto;
-import com.team6.finalproject.profile.entity.Profile;
-import com.team6.finalproject.profile.repository.ProfileRepository;
 import com.team6.finalproject.profile.service.ProfileService;
 import com.team6.finalproject.user.dto.SignupRequestDto;
 import com.team6.finalproject.user.entity.User;
 import com.team6.finalproject.user.entity.UserRoleEnum;
 import com.team6.finalproject.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -36,32 +30,5 @@ public class UserService {
         UserRoleEnum role = signupRequestDto.getRole();
 
         userRepository.save(new User(loginId,password,email,birth,role));
-    }
-
-    public ResponseEntity<ApiResponseDto> joinClub(Long id, User user) {
-        Club club = clubService.findClub(id);
-
-        // 거주지 입력 여부 판단
-        if(profileService.existValidLocate(user.getId())){
-            throw new IllegalArgumentException("거주지를 입력해주세요");
-        }
-
-        // 관심사 등록 여부 판단
-        if(profileService.existValidInterest(user.getId())) {
-            throw new IllegalArgumentException("관심사를 등록해주세요");
-        }
-
-        // 이미 가입한 동호회 예외 처리
-        if(memberService.existJoinClub(user, club)) {
-            throw new IllegalArgumentException("이미 가입한 동호회입니다.");
-        }
-
-        Member member = Member.builder()
-                .user(user)
-                .club(club)
-                .build();
-
-        memberService.saveMember(member);
-        return ResponseEntity.ok().body(new ApiResponseDto("동호회 가입 성공", 200));
     }
 }

--- a/src/main/java/com/team6/finalproject/user/service/UserService.java
+++ b/src/main/java/com/team6/finalproject/user/service/UserService.java
@@ -1,11 +1,19 @@
 package com.team6.finalproject.user.service;
 
-import com.team6.finalproject.common.config.PasswordConfig;
+import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.club.member.entity.Member;
+import com.team6.finalproject.club.member.service.MemberService;
+import com.team6.finalproject.club.service.ClubService;
+import com.team6.finalproject.common.dto.ApiResponseDto;
+import com.team6.finalproject.profile.entity.Profile;
+import com.team6.finalproject.profile.repository.ProfileRepository;
+import com.team6.finalproject.profile.service.ProfileService;
 import com.team6.finalproject.user.dto.SignupRequestDto;
 import com.team6.finalproject.user.entity.User;
 import com.team6.finalproject.user.entity.UserRoleEnum;
 import com.team6.finalproject.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +22,9 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ClubService clubService;
+    private final ProfileService profileService;
+    private final MemberService memberService;
     public void signup(SignupRequestDto signupRequestDto) {
         if(userRepository.findByUsername(signupRequestDto.getUserName()).isPresent()){
             throw new IllegalArgumentException("중복된 이름입니다.");
@@ -25,5 +36,32 @@ public class UserService {
         UserRoleEnum role = signupRequestDto.getRole();
 
         userRepository.save(new User(loginId,password,email,birth,role));
+    }
+
+    public ResponseEntity<ApiResponseDto> joinClub(Long id, User user) {
+        Club club = clubService.findClub(id);
+
+        // 거주지 입력 여부 판단
+        if(profileService.existValidLocate(user.getId())){
+            throw new IllegalArgumentException("거주지를 입력해주세요");
+        }
+
+        // 관심사 등록 여부 판단
+        if(profileService.existValidInterest(user.getId())) {
+            throw new IllegalArgumentException("관심사를 등록해주세요");
+        }
+
+        // 이미 가입한 동호회 예외 처리
+        if(memberService.existJoinClub(user, club)) {
+            throw new IllegalArgumentException("이미 가입한 동호회입니다.");
+        }
+
+        Member member = Member.builder()
+                .user(user)
+                .club(club)
+                .build();
+
+        memberService.saveMember(member);
+        return ResponseEntity.ok().body(new ApiResponseDto("동호회 가입 성공", 200));
     }
 }

--- a/src/test/java/com/team6/finalproject/club/service/ClubServiceImplTest.java
+++ b/src/test/java/com/team6/finalproject/club/service/ClubServiceImplTest.java
@@ -9,7 +9,6 @@ import com.team6.finalproject.club.interest.entity.InterestMajor;
 import com.team6.finalproject.club.interest.entity.InterestMinor;
 import com.team6.finalproject.club.interest.service.InterestMinorService;
 import com.team6.finalproject.club.repository.ClubRepository;
-import com.team6.finalproject.club.repository.ClubRepositoryCustom;
 import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.profile.entity.Profile;
 import com.team6.finalproject.profile.service.ProfileService;
@@ -129,7 +128,7 @@ class ClubServiceImplTest {
     @DisplayName("이미 존재하는 동호회 이름 생성시 예외 처리 성공 테스트")
     public void testCreateClub_ClubNameAlreadyExists() {
         // clubRepository.findByName()의 반환값 설정
-        when(clubRepository.findActiveClubByName("축구 클럽")).thenReturn(Optional.of(savedClub));
+        when(clubRepository.findByActiveClubName("축구 클럽")).thenReturn(Optional.of(savedClub));
 
         // 예외를 던지는지 확인
         assertThrows(IllegalArgumentException.class, () -> {
@@ -153,7 +152,7 @@ class ClubServiceImplTest {
     @DisplayName("동호회 폐쇄 성공 테스트")
     public void testDeleteClub_Success() {
         Long clubId = 1L;
-        when(clubRepository.findActiveByIdAndUsername(eq(clubId), eq(user.getUsername())))
+        when(clubRepository.findByActiveIdAndUsername(eq(clubId), eq(user.getUsername())))
                 .thenReturn(Optional.of(savedClub));
 
         ResponseEntity<ApiResponseDto> response = clubServiceImpl.deleteClub(clubId, user);
@@ -162,14 +161,14 @@ class ClubServiceImplTest {
         assertTrue(savedClub.isDeleted()); // 상태값이 true 로 즉, soft - delete 되었는지 확인
 
         // clubRepositoryCustom의 findByIdAndUsername 메서드가 호출되었는지 검증
-        verify(clubRepository, times(1)).findActiveByIdAndUsername(eq(clubId), eq(user.getUsername()));
+        verify(clubRepository, times(1)).findByActiveIdAndUsername(eq(clubId), eq(user.getUsername()));
     }
 
     @Test
     @DisplayName("삭제된 동호회 조회 테스트")
     public void testGetDeleteClub() {
         Long clubId = 1L;
-        when(clubRepository.findActiveByIdAndUsername(eq(clubId), eq(user.getUsername())))
+        when(clubRepository.findByActiveIdAndUsername(eq(clubId), eq(user.getUsername())))
                 .thenReturn(Optional.of(savedClub));
 
         // 동호회 삭제


### PR DESCRIPTION
[Member 테이블 설명]
- 동호회 가입 유저를 저장할 User(N) : Club(M) 관계의 Member 테이블 생성
- 테이블 자체에 중복 허용 불가 제약조건을 걸어줌으로써 중복된 회원 가입 방지

[동호회 가입 신청 및 승인  / 거절]
- Club Controller 에서 관리
- 거주지 입력과 등록 여부 판단 후 즉시 가입 또는 가입 신청

- ApplyJoinClub 는 User 와 Club 간 N:M 를 풀어낸 테이블로써, 선청서들을 적재

[ 동호회 즉시 가입 및 가입 신청 ]
- 동호회의 JoinType 이 IMMEDIATE 라면 즉시가입
- 동호회 유저를 관리하는 Member 테이블에 UniqueConstraint 를 걸어줌으로써 중복 가입 방지

- 동호회의 JoinType 이 APPROVE 라면 승인 대기
- hasPendingApplication 메서드를 통해 신청서 제출 여부 확인
- 통과되면 신청서 제출

[ 동호회 가입 승인 및 거절 ]
- 신청서를 조회하고 해당 신청서를 통해 동호회 조회
- 위에서 조회한 동호회의 개설자 이름과 현재 인가된 유저의 이름을 비교 후 권한 판단
- 이후 Controller 단에서 입력 받은 신청서의 상태값에 따라 승인 및 거절

[ 개선 예정 ]
- 동호회 개설자는 가입 신청 불가
- 동호회 멤버들에게 권한을 부여
- 개설자 및 스태프는 신청서 수리 가능, 일반유저는 불가능