### PR TITLE
[init] 동호회 멤버 조회

### DIFF
--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -4,6 +4,7 @@ import com.team6.finalproject.club.dto.ClubRequestDto;
 import com.team6.finalproject.club.dto.ClubResponseDto;
 import com.team6.finalproject.club.enums.ApprovalStateEnum;
 import com.team6.finalproject.club.enums.ClubRoleEnum;
+import com.team6.finalproject.club.member.dto.MemberInquiryDto;
 import com.team6.finalproject.club.service.ClubService;
 import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.security.UserDetailsImpl;
@@ -13,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,5 +50,10 @@ public class ClubController {
     @Secured(ClubRoleEnum.ClubRole.PRESIDENT)
     public ResponseEntity<ApiResponseDto> refuseJoinRequest(@PathVariable Long applyId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return clubService.processClubApproval(applyId, userDetails.getUser(), ApprovalStateEnum.REFUSE);
+    }
+
+    @GetMapping("/clubs/{clubId}/members") // 동호회 멤버 전체 조회
+    public List<MemberInquiryDto> getClubMember(@PathVariable Long clubId) {
+        return clubService.getClubMember(clubId);
     }
 }

--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -57,7 +57,7 @@ public class ClubController {
         return clubService.getClubMembers(clubId);
     }
 
-    @GetMapping("clubs/{clubId}/user/{userId}")
+    @GetMapping("clubs/{clubId}/user/{userId}") // 특정 멤버 조회
     public MemberInquiryDto readClubMember(@PathVariable Long clubId, @PathVariable Long userId) {
         return clubService.readClubMember(clubId, userId);
     }

--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -53,7 +53,12 @@ public class ClubController {
     }
 
     @GetMapping("/clubs/{clubId}/members") // 동호회 멤버 전체 조회
-    public List<MemberInquiryDto> getClubMember(@PathVariable Long clubId) {
-        return clubService.getClubMember(clubId);
+    public List<MemberInquiryDto> readClubMembers(@PathVariable Long clubId) {
+        return clubService.getClubMembers(clubId);
+    }
+
+    @GetMapping("clubs/{clubId}/user/{userId}")
+    public MemberInquiryDto readClubMember(@PathVariable Long clubId, @PathVariable Long userId) {
+        return clubService.readClubMember(clubId, userId);
     }
 }

--- a/src/main/java/com/team6/finalproject/club/member/dto/MemberInquiryDto.java
+++ b/src/main/java/com/team6/finalproject/club/member/dto/MemberInquiryDto.java
@@ -1,0 +1,16 @@
+package com.team6.finalproject.club.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInquiryDto {
+    private String nickName;
+    private String birth;
+    private String introduction;
+}

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustom.java
@@ -2,9 +2,12 @@ package com.team6.finalproject.club.member.repository;
 
 import com.team6.finalproject.club.member.entity.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepositoryCustom {
     public Optional<Member> findActiveUser(Long userId);
     public Optional<Member> findActiveUserAndClub(Long userId, Long clubId);
+
+    public List<Member> findActiveMembers(Long clubId);
 }

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustom.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 public interface MemberRepositoryCustom {
     public Optional<Member> findActiveUser(Long userId);
-    public Optional<Member> findActiveUserAndClub(Long userId, Long clubId);
-
+    public Optional<Member> findActiveUserAndClub(Long clubId, Long userId);
     public List<Member> findActiveMembers(Long clubId);
 }

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustomImpl.java
@@ -28,7 +28,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     @Override
-    public Optional<Member> findActiveUserAndClub(Long userId, Long clubId) {
+    public Optional<Member> findActiveUserAndClub(Long clubId, Long userId) {
         return
                 Optional.ofNullable(
                         jpaQueryFactory

--- a/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/club/member/repository/MemberRepositoryCustomImpl.java
@@ -5,13 +5,14 @@ import com.team6.finalproject.club.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.team6.finalproject.club.member.entity.QMember.member;
 
 @Repository
 @RequiredArgsConstructor
-public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
@@ -25,8 +26,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
                                 .fetchOne()
                 );
     }
+
     @Override
-    public Optional<Member> findActiveUserAndClub(Long userId, Long clubId){
+    public Optional<Member> findActiveUserAndClub(Long userId, Long clubId) {
         return
                 Optional.ofNullable(
                         jpaQueryFactory
@@ -37,5 +39,15 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
                                         .and(member.club.isDeleted.eq(false)))
                                 .fetchOne()
                 );
+    }
+
+    @Override
+    public List<Member> findActiveMembers(Long clubId) {
+        return
+                jpaQueryFactory
+                        .selectFrom(member)
+                        .where(member.club.id.eq(clubId)
+                                .and(member.isDeleted.eq(false)))
+                        .fetch();
     }
 }

--- a/src/main/java/com/team6/finalproject/club/member/service/MemberService.java
+++ b/src/main/java/com/team6/finalproject/club/member/service/MemberService.java
@@ -19,5 +19,9 @@ public interface MemberService {
     // 동호회 가입 여부
     public Boolean existJoinClub(Long userId, Long clubId);
 
+    // 멤버(복수) 조회
     public List<Member> findMembers(Long clubId);
+
+    // 특정 멤버(단일) 조회
+    public Member findMember(Long clubId, Long userId);
 }

--- a/src/main/java/com/team6/finalproject/club/member/service/MemberService.java
+++ b/src/main/java/com/team6/finalproject/club/member/service/MemberService.java
@@ -6,6 +6,8 @@ import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.user.entity.User;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
+
 
 public interface MemberService {
     // 멤버 권한 부여
@@ -16,4 +18,6 @@ public interface MemberService {
 
     // 동호회 가입 여부
     public Boolean existJoinClub(Long userId, Long clubId);
+
+    public List<Member> findMembers(Long clubId);
 }

--- a/src/main/java/com/team6/finalproject/club/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/member/service/MemberServiceImpl.java
@@ -46,9 +46,17 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findActiveUserAndClub(userId, clubId).isPresent();
     }
 
+    // 멤버(복수) 조회
     @Override
     public List<Member> findMembers(Long clubId) {
         return memberRepository.findActiveMembers(clubId);
+    }
+
+    // 특정 멤버(단일) 조회
+    @Override
+    public Member findMember(Long clubId, Long userId) {
+        return memberRepository.findActiveUserAndClub(clubId, userId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 회원입니다."));
     }
 
     // 멤버 조회

--- a/src/main/java/com/team6/finalproject/club/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/member/service/MemberServiceImpl.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
@@ -42,6 +44,11 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public Boolean existJoinClub(Long userId, Long clubId) {
         return memberRepository.findActiveUserAndClub(userId, clubId).isPresent();
+    }
+
+    @Override
+    public List<Member> findMembers(Long clubId) {
+        return memberRepository.findActiveMembers(clubId);
     }
 
     // 멤버 조회

--- a/src/main/java/com/team6/finalproject/club/service/ClubService.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubService.java
@@ -28,6 +28,9 @@ public interface ClubService {
     public ResponseEntity<ApiResponseDto> processClubApproval(Long applyId, User user, ApprovalStateEnum approvalState);
 
     // 동호회 멤버 전체 조회
-    public List<MemberInquiryDto> getClubMember(Long clubId);
+    public List<MemberInquiryDto> getClubMembers(Long clubId);
+
+    // 특정 멤버 조회
+    public MemberInquiryDto readClubMember(Long clubId, Long userId);
 }
 

--- a/src/main/java/com/team6/finalproject/club/service/ClubService.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubService.java
@@ -4,9 +4,12 @@ import com.team6.finalproject.club.dto.ClubRequestDto;
 import com.team6.finalproject.club.dto.ClubResponseDto;
 import com.team6.finalproject.club.entity.Club;
 import com.team6.finalproject.club.enums.ApprovalStateEnum;
+import com.team6.finalproject.club.member.dto.MemberInquiryDto;
 import com.team6.finalproject.common.dto.ApiResponseDto;
 import com.team6.finalproject.user.entity.User;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public interface ClubService {
 
@@ -23,5 +26,8 @@ public interface ClubService {
 
     // 동호회 가입 신청 승인 및 거절
     public ResponseEntity<ApiResponseDto> processClubApproval(Long applyId, User user, ApprovalStateEnum approvalState);
+
+    // 동호회 멤버 전체 조회
+    public List<MemberInquiryDto> getClubMember(Long clubId);
 }
 

--- a/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
@@ -41,11 +41,10 @@ public class ClubServiceImpl implements ClubService {
     private final MemberService memberService;
     private final ApplyJoinClubService applyJoinClubService;
 
-    // 동호회 멤버 조회
-    // 멤버 전체 조회
+    // 동호회 멤버 전체 조회
     @Override
     @Transactional(readOnly = true)
-    public List<MemberInquiryDto> getClubMember(Long clubId) {
+    public List<MemberInquiryDto> getClubMembers(Long clubId) {
         // 클럽에 속한 멤버 조회
         List<Member> members = memberService.findMembers(clubId);
 
@@ -58,6 +57,21 @@ public class ClubServiceImpl implements ClubService {
                         .introduction(member.getUser().getProfile().getIntroduction())
                         .build())
                 .toList();
+    }
+
+    // 동호회 멤버 선택 조회
+    @Override
+    @Transactional(readOnly = true)
+    public MemberInquiryDto readClubMember(Long clubId, Long userId) {
+        // 선택한 동호회와 특정 유저가 존재하는지 확인
+        Member member = memberService.findMember(clubId, userId);
+
+        // 반환
+        return  MemberInquiryDto.builder()
+                .nickName(member.getUser().getProfile().getNickname())
+                .birth(member.getUser().getBirth())
+                .introduction(member.getUser().getProfile().getIntroduction())
+                .build();
     }
 
     // 동호회 개설

--- a/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubServiceImpl.java
@@ -13,6 +13,7 @@ import com.team6.finalproject.club.enums.ClubRoleEnum;
 import com.team6.finalproject.club.enums.JoinTypeEnum;
 import com.team6.finalproject.club.interest.entity.InterestMinor;
 import com.team6.finalproject.club.interest.service.InterestMinorService;
+import com.team6.finalproject.club.member.dto.MemberInquiryDto;
 import com.team6.finalproject.club.member.entity.Member;
 import com.team6.finalproject.club.member.service.MemberService;
 import com.team6.finalproject.club.repository.ClubRepository;
@@ -27,6 +28,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j(topic = "club service 로직")
@@ -37,6 +40,25 @@ public class ClubServiceImpl implements ClubService {
     private final ProfileService profileService;
     private final MemberService memberService;
     private final ApplyJoinClubService applyJoinClubService;
+
+    // 동호회 멤버 조회
+    // 멤버 전체 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberInquiryDto> getClubMember(Long clubId) {
+        // 클럽에 속한 멤버 조회
+        List<Member> members = memberService.findMembers(clubId);
+
+        // 반환
+        // 성별 및 이미지도 함께 반환 예정
+        return members.stream()
+                .map(member -> MemberInquiryDto.builder()
+                        .nickName(member.getUser().getProfile().getNickname())
+                        .birth(member.getUser().getBirth())
+                        .introduction(member.getUser().getProfile().getIntroduction())
+                        .build())
+                .toList();
+    }
 
     // 동호회 개설
     @Override
@@ -116,7 +138,7 @@ public class ClubServiceImpl implements ClubService {
         // Soft - Delete 메서드
         // 동호회 개설자가 아니면 삭제 불가
         // 동호회 멤버도 delete 하기
-        if(!targetClub.getUsername().equals(user.getUsername())) {
+        if (!targetClub.getUsername().equals(user.getUsername())) {
             throw new IllegalArgumentException("권한이 없습니다");
         }
 

--- a/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
@@ -6,6 +6,7 @@ import com.team6.finalproject.profile.dto.ProfileResponseDto;
 import com.team6.finalproject.profile.entity.Profile;
 import com.team6.finalproject.profile.repository.ProfileRepository;
 import com.team6.finalproject.user.entity.User;
+import com.team6.finalproject.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.io.IOException;
 public class ProfileServiceImpl implements ProfileService {
 
     private final ProfileRepository profileRepository;
+    private final UserService userService;
     private final FileUploader fileUploader;
 
     // 프로필 생성
@@ -31,6 +33,10 @@ public class ProfileServiceImpl implements ProfileService {
                 .user(user)
                 .build();
         profileRepository.save(profile);
+
+        user.setProfile(profile);
+        userService.saveUser(user);
+
         return new ProfileResponseDto(profile);
     }
 

--- a/src/main/java/com/team6/finalproject/user/service/UserService.java
+++ b/src/main/java/com/team6/finalproject/user/service/UserService.java
@@ -1,8 +1,5 @@
 package com.team6.finalproject.user.service;
 
-import com.team6.finalproject.club.member.service.MemberService;
-import com.team6.finalproject.club.service.ClubService;
-import com.team6.finalproject.profile.service.ProfileService;
 import com.team6.finalproject.user.dto.SignupRequestDto;
 import com.team6.finalproject.user.entity.User;
 import com.team6.finalproject.user.entity.UserRoleEnum;
@@ -16,9 +13,6 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final ClubService clubService;
-    private final ProfileService profileService;
-    private final MemberService memberService;
     public void signup(SignupRequestDto signupRequestDto) {
         if(userRepository.findByUsername(signupRequestDto.getUserName()).isPresent()){
             throw new IllegalArgumentException("중복된 이름입니다.");
@@ -30,5 +24,9 @@ public class UserService {
         UserRoleEnum role = signupRequestDto.getRole();
 
         userRepository.save(new User(loginId,password,email,birth,role));
+    }
+
+    public void saveUser(User user) {
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
1. 동호회 전체 멤버 조회
- 조회 간 프로필 닉네임 기준 오름차순 정렬
- 동일 닉네임일 경우 생년월일 오름차순  정렬
- 추후 닉네임을 중복 불가 설정시, 본명과 닉네임의 분리가 필요해 보임

2. 동호회 특정 멤버 조회