### PR TITLE
[refactor] 프로필 닉네임 중복 허용

### DIFF
--- a/src/main/java/com/team6/finalproject/profile/dto/InterestRequestDto.java
+++ b/src/main/java/com/team6/finalproject/profile/dto/InterestRequestDto.java
@@ -1,16 +1,12 @@
 package com.team6.finalproject.profile.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
-@Builder // 테스트에서 사용
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter // 테스트에서 사용
 public class InterestRequestDto {
     private List<Long> minorId;
 }

--- a/src/main/java/com/team6/finalproject/profile/dto/LikeClubRequestDto.java
+++ b/src/main/java/com/team6/finalproject/profile/dto/LikeClubRequestDto.java
@@ -1,14 +1,10 @@
 package com.team6.finalproject.profile.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@Builder // 테스트에서 사용
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter // 테스트에서 사용
 public class LikeClubRequestDto {
     private Long clubId;
 }

--- a/src/main/java/com/team6/finalproject/profile/dto/ProfileRequestDto.java
+++ b/src/main/java/com/team6/finalproject/profile/dto/ProfileRequestDto.java
@@ -1,14 +1,10 @@
 package com.team6.finalproject.profile.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@Builder // 테스트에서 사용
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter // 테스트에서 사용
 public class ProfileRequestDto {
     private String nickname;
     private String introduction;

--- a/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/team6/finalproject/profile/service/ProfileServiceImpl.java
@@ -33,15 +33,10 @@ public class ProfileServiceImpl implements ProfileService {
                 .user(user)
                 .build();
 
-        if (profileRepository.findByNickname(requestDto.getNickname()).isPresent()) {
-            throw new IllegalArgumentException("이미 사용중인 닉네임입니다.");
-        }
-
         profileRepository.save(profile);
 
-        user.setProfile(profile);
+        user.setProfile(profile); // Setter 제거 시 변경
         userService.saveUser(user);
-
         return new ProfileResponseDto(profile);
     }
 

--- a/src/test/java/com/team6/finalproject/profile/likeclub/service/LikeClubServiceImplTest.java
+++ b/src/test/java/com/team6/finalproject/profile/likeclub/service/LikeClubServiceImplTest.java
@@ -78,9 +78,8 @@ class LikeClubServiceImplTest {
                 .club(club)
                 .build();
         // 관심 동호회 요청
-        LikeClubRequestDto requestDto = LikeClubRequestDto.builder()
-                .clubId(1L)
-                .build();
+        LikeClubRequestDto requestDto = new LikeClubRequestDto();
+        requestDto.setClubId(1L);
 
         when(profileService.findProfileByUserId(user.getId())).thenReturn(profile);
         when(clubService.findClub(requestDto.getClubId())).thenReturn(club);

--- a/src/test/java/com/team6/finalproject/profile/profileinterest/service/ProfileInterestServiceImplTest.java
+++ b/src/test/java/com/team6/finalproject/profile/profileinterest/service/ProfileInterestServiceImplTest.java
@@ -68,9 +68,9 @@ class ProfileInterestServiceImplTest {
                 .build();
 
         List<Long> minorIds = Arrays.asList(1L, 2L);
-        InterestRequestDto requestDto = InterestRequestDto.builder()
-                .minorId(minorIds)
-                .build();
+        InterestRequestDto requestDto = new InterestRequestDto();
+        requestDto.setMinorId(minorIds);
+
         Long request1 = requestDto.getMinorId().get(0);
         Long request2 = requestDto.getMinorId().get(1);
 

--- a/src/test/java/com/team6/finalproject/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/team6/finalproject/profile/service/ProfileServiceImplTest.java
@@ -92,9 +92,8 @@ class ProfileServiceImplTest {
         when(profileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
 
         // 수정할 닉네임 주입
-        ProfileRequestDto requestDto = ProfileRequestDto.builder()
-                .nickname("닉네임 수정")
-                .build();
+        ProfileRequestDto requestDto = new ProfileRequestDto();
+        requestDto.setNickname("닉네임 수정");
 
         // when
         profileService.updateProfile(requestDto, userDetails.getUser());


### PR DESCRIPTION
- 프로필 생성 시 닉네임 중복 제한 로직 삭제
- 단위테스트를 위한 Dto의 Builder들 Setter로 변경
- 단위 테스트 수정