### PR TITLE
[init] : 유저 최적합 동호회 추천 알고리즘 구현

### DIFF
--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -100,4 +100,9 @@ public class ClubController {
     public List<ClubResponseDto> clubsByPopularity() throws NotExistResourceException {
         return clubService.clubsByPopularity();
     }
+
+    @GetMapping("/clubs/recommend") // 유저에게 최적합 동호회 추천
+    public List<ClubResponseDto> recommendClubs(@RequestParam("radius") double radius, @AuthenticationPrincipal UserDetailsImpl userDetails)  {
+        return clubService.findRecommendedClubsForUser(radius, userDetails.getUser());
+    }
 }

--- a/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.team6.finalproject.club.repository;
 
 import com.team6.finalproject.club.entity.Club;
+import com.team6.finalproject.user.entity.User;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +15,5 @@ public interface ClubRepositoryCustom {
     public List<Club> findClubsByUserAge(int userAge); // 유저 연령대 별 조회
     public List<Club> findClubsByRecent(); // 최근 개설된 동호회 조회
     public List<Club> findPopularClubs(); // 인기 동호회 조회
+    public List<Club> findRecommendedClubs(User user); // 연령대와 관심가 맞는 동호회 조회
 }

--- a/src/main/java/com/team6/finalproject/club/service/ClubService.java
+++ b/src/main/java/com/team6/finalproject/club/service/ClubService.java
@@ -57,5 +57,8 @@ public interface ClubService {
 
     // 인기 급상승 동호회 조회
     public List<ClubResponseDto> clubsByPopularity() throws NotExistResourceException;
+
+    // 거리, 연령대, 관심사가 모두 부합하는 동호회 조회
+    public List<ClubResponseDto> findRecommendedClubsForUser(double radius, User user);
 }
 


### PR DESCRIPTION
1. radius 를 param 으로 받습니다.
2. 이는 radius 내의 동호회만 추천해주기 위함이며, 최소 반경은 5km 이상입니다.
3. queryDsl 을 통해 연령대, 관심사 매칭을 시켜주었습니다.
4. 이후 조회된 클럽을 service 로직에서 radius 내의 동호회만 조회할 수 있도록 필터를 걸어주었고,
5. 가까운 순으로 정렬하여 리스트로 반환합니다.