### PR TITLE
[hotfix] : 동호회 소주제 선택 조회 간 해당 값에 맞지 않는 데이터가 조회되는 현상 해결

### DIFF
--- a/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/finalproject/club/repository/ClubRepositoryCustomImpl.java
@@ -63,7 +63,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
         return
                 jpaQueryFactory
                         .selectFrom(club)
-                        .where(club.minor.interestMajor.id.eq(minorId)
+                        .where(club.minor.id.eq(minorId)
                                 .and(club.isDeleted.eq(false)))
                         .orderBy(club.createdAt.desc()) // 최신순 정렬
                         .fetch();


### PR DESCRIPTION
- 쿼리에서 club.minor.interestMajor.id.eq(minorId 를 .where(club.minor.id.eq(minorId) 로 변경