### PR TITLE
[hotfix] : 동호회 상세 페이지 조회 에러 개선

### DIFF
--- a/src/main/java/com/team6/finalproject/club/controller/ClubController.java
+++ b/src/main/java/com/team6/finalproject/club/controller/ClubController.java
@@ -2,14 +2,12 @@ package com.team6.finalproject.club.controller;
 
 import com.team6.finalproject.advice.custom.*;
 import com.team6.finalproject.club.apply.dto.ClubAppliesResponseDto;
-import com.team6.finalproject.club.apply.entity.ApplyJoinClub;
 import com.team6.finalproject.club.apply.service.ApplyJoinClubService;
 import com.team6.finalproject.club.dto.ClubRequestDto;
 import com.team6.finalproject.club.dto.ClubResponseDto;
 import com.team6.finalproject.club.dto.ReadInterestMajorDto;
 import com.team6.finalproject.club.enums.ApprovalStateEnum;
 import com.team6.finalproject.club.enums.ClubRoleEnum;
-import com.team6.finalproject.club.interest.service.InterestMinorService;
 import com.team6.finalproject.club.member.dto.MemberInquiryDto;
 import com.team6.finalproject.club.member.service.MemberService;
 import com.team6.finalproject.club.service.ClubService;
@@ -55,13 +53,13 @@ public class ClubController {
     }
     @GetMapping("/club-detail/{id}") // 동호회 상세 조회
     public String clubPage(@PathVariable("id") Long id, Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) throws NotExistResourceException {
-        model.addAttribute("clubId", id);
-        model.addAttribute("currentUsername", userDetails.getUsername());
-        model.addAttribute("clubUsername", clubService.findClub(id).getUsername());
-        model.addAttribute("likeStatus", likeClubService.isLikeClub(id, userDetails.getUser()));
-        model.addAttribute("memberStatus", memberService.existJoinClub(userDetails.getUser().getId(), id));
-        model.addAttribute("applyStatus", applyJoinClubService.hasPendingApplication(userDetails.getUser().getId(), id));
-        return "club-detail";
+            model.addAttribute("clubId", id);
+            model.addAttribute("currentUsername", userDetails.getUsername());
+            model.addAttribute("clubUsername", clubService.findClub(id).getUsername());
+            model.addAttribute("likeStatus", likeClubService.isLikeClub(id, userDetails.getUser()));
+            model.addAttribute("memberStatus", memberService.existJoinClub(userDetails.getUser().getId(), id));
+            model.addAttribute("applyStatus", applyJoinClubService.hasPendingApplication(userDetails.getUser().getId(), id));
+            return "club-detail";
     }
 
     @GetMapping("/my-club") // 개설한 동호회 목록 조회

--- a/src/main/resources/templates/sub-main.html
+++ b/src/main/resources/templates/sub-main.html
@@ -347,11 +347,14 @@
                                     alert("로그인이 필요한 서비스입니다.");
                                     window.location.href = "/login";
                                 });
+                            } else if (response.status === 400) {  // 프로필 생성 필요한 경우
+                                return response.json().then(data => {
+                                    alert("프로필이 필요한 페이지입니다. 프로필 생성 페이지로 이동합니다.");
+                                    window.location.href = "/api/profile/create";
+                                });
                             } else if (response.ok) {
-                                // 정상적인 응답인 경우 페이지를 이동시킨다.
                                 window.location.href = `/api/club-detail/${clubId}`;
                             } else {
-                                // 다른 에러 처리
                                 return response.text().then(text => {
                                     console.error(text);
                                 });


### PR DESCRIPTION
프로필이 존재하지 않을 경우 동호회 상세 페이지 조회가 안되는 문제식별
이에 프로필 생성이 필요하다는 알림 반환 후 프로필 생성 페이지로 리다이렉트