### PR TITLE
[refactor] 동호회 생성 기본 이미지

### DIFF
--- a/src/main/resources/static/js/openClub.js
+++ b/src/main/resources/static/js/openClub.js
@@ -126,6 +126,11 @@ function submit() {
         locate: locate
     };
 
+    // 파일 선택하지 않았을 때 기본 이미지 요청
+    if (!file) {
+        file = new File([], "empty", {type: "image/png"});
+    }
+
     let formData = new FormData();
     formData.append('clubRequestDto', new Blob([JSON.stringify(clubDto)], {type: 'application/json'}));
     formData.append('file', file); // 파일 추가


### PR DESCRIPTION
- 동호회 생성 시 이미지 선택하지 않으면 기본이미지(미쯔 로고)들어가도록 수정